### PR TITLE
Time Kafka offset commit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val common = (project in file("common")).
   settings(
     name := "scheduler-common",
     libraryDependencies ++= Seq(
-      "com.pagerduty" %% "metrics-api" % "1.0.8",
+      "com.pagerduty" %% "metrics-api" % "1.1.0",
       "org.json4s"   %% "json4s-jackson" % "3.3.0",
       "com.twitter" %% "util-core" % "6.22.2",
       "ch.qos.logback" % "logback-classic" % "1.1.3",
@@ -87,7 +87,7 @@ lazy val scalaApi = (project in file("scala-api")).
   settings(
     name := "scheduler-scala-api",
     libraryDependencies ++= Seq(
-      "com.pagerduty" %% "metrics-api" % "1.0.7",
+      "com.pagerduty" %% "metrics-api" % "1.1.0",
       "org.scalatest" %% "scalatest" % "2.2.6" % "test",
       "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test"
     )
@@ -106,7 +106,7 @@ lazy val root = (project in file(".")).
       val scalatraVersion = "2.4.0"
       val kafkaConsumerVersion = "0.3.2"
       Seq(
-        "com.pagerduty" %% "metrics-api" % "1.0.7",
+        "com.pagerduty" %% "metrics-api" % "1.1.0",
         "com.pagerduty" %% "eris-pd" % "3.0.2" exclude("org.slf4j", "slf4j-log4j12"),
         "com.pagerduty" %% "kafka-consumer" % kafkaConsumerVersion,
         "com.pagerduty" %% "kafka-consumer-test-support" % kafkaConsumerVersion  exclude("org.slf4j", "slf4j-simple"),

--- a/common/src/test/scala/com/pagerduty/scheduler/LoggingSupportSpec.scala
+++ b/common/src/test/scala/com/pagerduty/scheduler/LoggingSupportSpec.scala
@@ -1,10 +1,11 @@
 package com.pagerduty.scheduler
 
-import com.pagerduty.metrics.{ Event, Metrics }
+import com.pagerduty.metrics.{ Event, Metrics, NullMetrics }
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{ Matchers, WordSpecLike }
 import org.slf4j.Logger
+
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Promise }
 import scala.util.Try
@@ -14,7 +15,7 @@ class LoggingSupportSpec extends WordSpecLike with Matchers with Eventually with
 
   // Because of buggy mocking (said lex).
   case class AddMetricsInvocation(name: String, tags: Seq[(String, String)])
-  class MockStats extends Metrics {
+  class MockStats extends NullMetrics {
     private var _invocations = Seq.empty[AddMetricsInvocation]
     def invocations = this.synchronized {
       _invocations
@@ -22,10 +23,6 @@ class LoggingSupportSpec extends WordSpecLike with Matchers with Eventually with
     override def histogram(name: String, value: Int, tags: (String, String)*): Unit = this.synchronized {
       _invocations :+= AddMetricsInvocation(name, tags)
     }
-
-    // Unused
-    override def count(name: String, count: Int, tags: (String, String)*): Unit = ???
-    override def recordEvent(event: Event): Unit = ???
   }
   val successTag = "result" -> "success"
   val failureTag = "result" -> "failure"

--- a/src/main/scala/com/pagerduty/scheduler/Scheduler.scala
+++ b/src/main/scala/com/pagerduty/scheduler/Scheduler.scala
@@ -89,7 +89,7 @@ class SchedulerImpl(
     }
     new SchedulerKafkaConsumer(
       schedulerSettings, config, cluster, keyspace,
-      kafkaConsumerProps, taskExecutorServiceFactory, logging
+      kafkaConsumerProps, taskExecutorServiceFactory, logging, metrics
     )
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "6.0.3"
+version in ThisBuild := "6.0.4"


### PR DESCRIPTION
This PR uses a new version of `metrics-api` that allows us to time things (see https://github.com/PagerDuty/scala-metrics/pull/3).

Use that method to provide an implementation of `ConsumerMetrics` to `SimpleKafkaConsumer`.

PD internal ticket [CORE-950].