### PR TITLE
Enable Cassandra3 usage for Scheduler integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@ scala:
   - 2.11.7
 jdk:
   - oraclejdk7
+  - oraclejdk8
+env:
+  - CASS=cassandra
+  - CASS=cassandra3
+matrix:
+  exclude:
+  - env: CASS=cassandra3
+    jdk: oraclejdk7
 sudo: required
 dist: trusty
 cache:
@@ -24,7 +32,7 @@ cache:
 before_install:
   - curl https://raw.githubusercontent.com/PagerDuty/pd-travis-deps/master/zookeeper | /bin/sh
   - curl https://raw.githubusercontent.com/PagerDuty/pd-travis-deps/master/kafka | /bin/sh
-  - curl https://raw.githubusercontent.com/PagerDuty/pd-travis-deps/master/cassandra | /bin/sh
+  - curl https://raw.githubusercontent.com/PagerDuty/pd-travis-deps/master/$CASS | /bin/sh
   - cd $TRAVIS_BUILD_DIR
   - mkdir ~/.sbt
   - cp .travisci/credentials.sbt ~/.sbt


### PR DESCRIPTION
(PD internal linked Jira ticket: CORE-872)

The build matrix in this implementation includes permutations of [oraclejdk8, oraclejdk7], and [Cassandra 3.7, Cassandra 1.2.19], but specifically excludes the combination of oraclejdk7 with Cassandra 3.7 (as Cassandra 3+ requires Java 8)