### PR TITLE
Make Task a final case class, since a class extending Task will never serialize properly

### DIFF
--- a/common/src/main/scala/com/pagerduty/scheduler/model/Task.scala
+++ b/common/src/main/scala/com/pagerduty/scheduler/model/Task.scala
@@ -36,7 +36,7 @@ import org.json4s.jackson.Serialization.{ read, write }
  * @param version Serialization version number so we can make changes in the future.
  *
  */
-case class Task(
+final case class Task(
     orderingId: Task.OrderingId,
     scheduledTime: Instant,
     uniquenessKey: Task.UniquenessKey,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "8.2.3"
+version in ThisBuild := "9.0.0"


### PR DESCRIPTION
We use `json4s` for serialization, and that lib depends on a `Task` being a case class to serialize it properly. For example:

``` scala
class Foo extends Task(//...)
```

will never serialize properly to JSON (instead it silently only serializes the `scheduledTime` field).

This PR makes `Task` final to prevent people from making this mistake.